### PR TITLE
Switch to name prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "lb" {
-  name               = "outyet-lb"
+  name_prefix        = "outyet-lb"
   internal           = false
   load_balancer_type = "application"
   security_groups    = ["${aws_security_group.lb-sg.id}"]

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "lb" {
-  name_prefix        = "outyet-lb"
+  name_prefix        = "outyet"
   internal           = false
   load_balancer_type = "application"
   security_groups    = ["${aws_security_group.lb-sg.id}"]


### PR DESCRIPTION
Switch to using `name-prefix` instead of `name` to allow multiple instances of this module to be launched in AWS