### PR TITLE
add https support with a prebuilt AWS ACM cert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,8 +52,8 @@ resource "aws_lb_listener" "listener-https" {
   load_balancer_arn = "${aws_lb.lb.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy = "ELBSecurityPolicy-2016-08"
-  certificate_arn = "${var.tls_cert_arn}"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "${var.tls_cert_arn}"
 
   default_action {
     type             = "forward"

--- a/main.tf
+++ b/main.tf
@@ -19,15 +19,41 @@ resource "aws_security_group" "lb-frontend-sg" {
     description = "Allow HTTP port 80 traffic"
   }
 
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTPS port 443 traffic"
+  }
+
   lifecycle {
     create_before_destroy = true
   }
 }
 
-resource "aws_lb_listener" "listener" {
+resource "aws_lb_listener" "listener-http" {
   load_balancer_arn = "${aws_lb.lb.arn}"
   port              = "80"
   protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "listener-https" {
+  load_balancer_arn = "${aws_lb.lb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+  certificate_arn = "${var.tls_cert_arn}"
 
   default_action {
     type             = "forward"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "target_group_arn" {
   value = "${aws_lb_target_group.target-group.arn}"
 }
+
+output "lb_dns_name" {
+  value = "${aws_lb.lb.dns_name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,7 @@ variable "autoscaling_group_name" {
 variable "backend_app_sg_id" {
 
 }
+
+variable "tls_cert_arn" {
+
+}


### PR DESCRIPTION
- Add HTTPS listener
- Modify existing HTTP listener to redirect traffic to HTTPS
- Update ingress security group to allow HTTPS traffic
- Requires the ARN of a TLS cert in AWS ACM, so that it can be attached to the HTTPS listener 
- Output the LB autogenerated DNS name 